### PR TITLE
BlobMedia constructor expects a content byte string

### DIFF
--- a/downlink/python/anvil/__init__.py
+++ b/downlink/python/anvil/__init__.py
@@ -66,7 +66,9 @@ _unicode_string_type = str if sys.version_info >= (3,) else unicode
 class BlobMedia(Media):
     def __init__(self, content_type, content, name=None):
         self._content_type = content_type
-        if isinstance(content, _unicode_string_type):
+        if content is None:
+            raise TypeError("BlobMedia content must be a byte string.")
+        elif isinstance(content, _unicode_string_type):
             content = content.encode("utf-8")
         self._bytes = content
         self._name = name

--- a/downlink/python/anvil/__init__.py
+++ b/downlink/python/anvil/__init__.py
@@ -60,13 +60,14 @@ class Media(object):
         return None
 
 
+_byte_string_type = bytes if sys.version_info >= (3,) else str
 _unicode_string_type = str if sys.version_info >= (3,) else unicode
 
 
 class BlobMedia(Media):
     def __init__(self, content_type, content, name=None):
         self._content_type = content_type
-        if content is None:
+        if not isinstance(content, _byte_string_type):
             raise TypeError("BlobMedia content must be a byte string.")
         elif isinstance(content, _unicode_string_type):
             content = content.encode("utf-8")


### PR DESCRIPTION
This resolves https://anvil.works/forum/t/bug-corrupted-blobmedia-raises-an-exception-at-a-weird-location/5385.

If you pass None as the second argument of BlobMedia it successfully creates an object but that object will raise `TypeError: 'NoneType' has no length` whenever it is used. This creates some trippy experiences trying to track down the `TypeError`.

For example:

`img = BlobMedia("image/png", None)  # executes successfully` 
`print(img)  # raises the TypeError`

The expected behavior is that if the BlobMedia constructor recieves invalid input it is the constructor that throws the exception not the `__repr__` or `__str__`.