### PR TITLE
Add exception argument for Google integration

### DIFF
--- a/services/anvil/google/__init__.py
+++ b/services/anvil/google/__init__.py
@@ -7,4 +7,7 @@ def get_config():
 	global _config
 	if _config is None:
 		_config = anvil.server.call("anvil.private.google.get_config")
+		if _config is None:
+			raise Exception("Google integration has not been configured. "\
+					"See https://anvil.works/docs/integrations/google for more information")
 	return _config


### PR DESCRIPTION
Hey, folks! Hope it's okay to send a quick PR like this instead of opening a forum post.

I just ran into a foolish situation. I had configured my Uplink code with my production key. When I tried to write some Uplink code to access my Google Drive, I wound up spending a good few minutes trying to figure out why the heck I could access the integration on the server, but not in Uplink. An exception argument like this would help other idiots in the future.

I'd also recommend doing the same for the other integrations.

Thanks! Love your product!