### PR TITLE
Docs: Correct two docs links in dependencies.md

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,6 +1,6 @@
 # Anvil App Server Dependencies
 
-[Anvil](https://anvil.works) gives you the ability to reuse [Forms](/docs/client/components/forms), [Custom Components](/docs/client/custom-components) and code from one Anvil app in another.
+[Anvil](https://anvil.works) gives you the ability to reuse [Forms](https://anvil.works/docs/client/components/forms), [Custom Components](https://anvil.works/docs/client/custom-components) and code from one Anvil app in another.
 
 Follow this how-to guide to learn how to take two apps that depend on one another, [clone them onto your local machine](https://anvil.works/docs/version-control/git), and run them locally using the Anvil App Server. For information on how dependencies work in Anvil, see the [reference docs](https://anvil.works/docs/deployment/dependencies).
 


### PR DESCRIPTION
I searched README.md and all Markdown in the 'doc' directory for similar link mistakes but did not find any others.