### PR TITLE
remove youtube by default for GDPR compliancy

### DIFF
--- a/client/runner.html
+++ b/client/runner.html
@@ -282,7 +282,7 @@
 
 <!--   <script src="{{cdn-origin}}/runtime/node_modules/core-js-bundle/minified.js?buildTime=0" crossorigin></script>
  -->
-  <script src="https://www.youtube.com/iframe_api"></script>
+    <!-- <script src="https://www.youtube.com/iframe_api"></script> -->
   <script>
     function gm_authFailure(e) { window.googleMapsAuthFailure = true; };
   </script>


### PR DESCRIPTION
It might be too brutal.
A softer mechanism like Google Maps (test of window["google"] + gm_authFailure here) might do the trick?