### PR TITLE
Use map to improve speed of WrappedList init / extend by ~60%

### DIFF
--- a/client/py/anvil/util.py
+++ b/client/py/anvil/util.py
@@ -84,8 +84,7 @@ class WrappedObject(dict):
 @serializable_type
 class WrappedList(list):
     def __init__(self, lst=[]):
-        for x in lst:
-            self.append(x)
+        super().__init__(map(_wrap, lst))
 
     def append(self, item):
         list.append(self, _wrap(item))

--- a/client/py/anvil/util.py
+++ b/client/py/anvil/util.py
@@ -84,13 +84,19 @@ class WrappedObject(dict):
 @serializable_type
 class WrappedList(list):
     def __init__(self, lst=[]):
-        list.__init__(self, map(_wrap, lst))
+        if isinstance(lst, (WrappedObject, WrappedList)):
+            list.__init__(self, lst)
+        else:
+            list.__init__(self, map(_wrap, lst))
 
     def append(self, item):
         list.append(self, _wrap(item))
 
     def extend(self, items):
-        list.extend(self, map(_wrap, items))
+        if isinstance(items, (WrappedObject, WrappedList)):
+            list.extend(self, items)
+        else:
+            list.__init__(self, map(_wrap, items))
 
     def insert(self, offset, item):
         list.insert(self, offset, _wrap(item))

--- a/client/py/anvil/util.py
+++ b/client/py/anvil/util.py
@@ -91,8 +91,7 @@ class WrappedList(list):
         list.append(self, _wrap(item))
 
     def extend(self, items):
-        for i in items:
-            self.append(i)
+        super().extend(map(_wrap, items))
 
     def insert(self, offset, item):
         list.insert(self, offset, _wrap(item))

--- a/client/py/anvil/util.py
+++ b/client/py/anvil/util.py
@@ -84,13 +84,13 @@ class WrappedObject(dict):
 @serializable_type
 class WrappedList(list):
     def __init__(self, lst=[]):
-        super().__init__(map(_wrap, lst))
+        list.__init__(self, map(_wrap, lst))
 
     def append(self, item):
         list.append(self, _wrap(item))
 
     def extend(self, items):
-        super().extend(map(_wrap, items))
+        list.extend(self, map(_wrap, items))
 
     def insert(self, offset, item):
         list.insert(self, offset, _wrap(item))


### PR DESCRIPTION
## Purpose

This PR improves the performance of WrappedList by using `map`.

## Summary of changes

I used `map` and some short-circuiting to improve performance.

All code is commented, with docstrings, and typed where relevant.

##  Validation steps

✔️ Created an environment (for me, a Poetry environment, because I am using Python 3.10)
✔️ Installed anvil-runtime Python downlink, using path installation
✔️ Ran tests (see #75) in the environment. Confirmed that all tests pass.
✔️ Ran quick-and-dirty timing script

```
Speedup (before / after)
>> instantiation with 1000 elements:           1.6896897566622429
>> extending by 1000 elements:                 1.6881427085098548
>> appending 1000 elements:                    0.992154109612771
>> inserting 1000 elements:                    0.9807249483142917
>> deepcopy sqrt(1000) x sqrt(1000) elements:   0.962684461929972
```